### PR TITLE
Update scraper to not crash

### DIFF
--- a/tigerpath/scraper/scrape_all.py
+++ b/tigerpath/scraper/scrape_all.py
@@ -22,9 +22,13 @@ def get_all_courses():
 
             # add dist_area to models
             for course in scrape_all_courses(term_code):
-                fetch_course = Course.objects.get(registrar_id = str(term_code) + str(course["courseid"]))
-                fetch_course.dist_area = course["area"]
-                fetch_course.save()
+                try:
+                    fetch_course = Course.objects.get(registrar_id = str(term_code) + str(course["courseid"]))
+                    fetch_course.dist_area = course["area"]
+                    fetch_course.save()
+                except:
+                    print(course)
+                    print(str(term_code) + str(course['courseid']))
         except Exception as e:
             raise e
 


### PR DESCRIPTION
Sometimes recal doesn't scrape a course that the 2nd scraper scrapes so the 2nd scraper throws an error when it tries to get the course.