### PR TITLE
Add logging in without using CAS

### DIFF
--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -9,3 +9,6 @@ WEBPACK_LOADER = {
 
 DEBUG = True
 ADMIN_ENABLED = DEBUG
+
+# redirect to index after logging in as admin
+LOGIN_REDIRECT_URL = 'index'

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
+from django.contrib.auth import views as auth_views
 
 urlpatterns = [
     path('', include('tigerpath.urls')),
@@ -23,3 +24,4 @@ urlpatterns = [
 
 if settings.ADMIN_ENABLED:
     urlpatterns.append(path('admin/', admin.site.urls))
+    urlpatterns.append(path('login/admin', auth_views.login, {'template_name': 'admin/login.html'}))

--- a/tigerpath/templates/tigerpath/admin/login.html
+++ b/tigerpath/templates/tigerpath/admin/login.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+
+{% block title %}Login{% endblock %}
+
+{% block content %}
+  <h2>Login</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Login</button>
+  </form>
+{% endblock %}


### PR DESCRIPTION
Added ability to log in using Django's authentication system directly without using CAS. This is only enabled in development mode, and is so that we can log in even after our Princeton NetIDs don't work anymore.

Please check that this doesn't break the regular logging in using Princeton CAS (I can't check this).