### PR TITLE
Add SSL support

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -14,12 +14,11 @@ WEBPACK_LOADER = {
         }
 }
 
+
 # Security
-# CSRF_COOKIE_SECURE = True  # should be uncommented when SSL is implemented
-
-# SESSION_COOKIE_SECURE = True  # should be uncommented when SSL is implemented
-
-# SECURE_SSL_REDIRECT = True  # should be uncommented when SSL is implemented
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True
+SECURE_SSL_REDIRECT = True
 
 
 # Get email notifs about errors. Not scalable, so look into sentry later: https://docs.sentry.io


### PR DESCRIPTION
Upgraded Heroku to a hobby dyno, enabled HTTPS on their end, and added SSL support in Django. The dev site needs to be tested after merging, can't test locally.