### PR TITLE
Add a nicer message for unsupported majors

### DIFF
--- a/frontend/src/Search.js
+++ b/frontend/src/Search.js
@@ -143,7 +143,7 @@ function renderRequirements(){
                             <p style={{padding: '5px'}}>In the meantime, you can track your AB degree requirements below.
                             </p>
                           </div>;
-                popoverContent = name;
+                popoverContent = 'The ' + name + ' major is not supported yet.';
               }
 
               // render requirements

--- a/frontend/src/Search.js
+++ b/frontend/src/Search.js
@@ -93,7 +93,20 @@ function renderRequirements(){
           });
           ReactDOM.render(
            data.map((mainReq, index)=>{
-              if(!(typeof mainReq === "object")) return(<div style={{padding: '5px'}}>The {mainReq} major is not supported yet.</div>)
+              if(!(typeof mainReq === "object")) {
+                let mainReqLabel = <div className='reqLabel'
+                                    title={'<span>' + mainReq + '</span>'}>
+                                      <div className='my-arrow root-arrow'></div>
+                                      {mainReq}
+                                   </div>
+                return (<TreeView key={index} itemClassName={"tree-root"} childrenClassName="tree-sub-reqs" nodeLabel={mainReqLabel}>
+                          <div style={{padding: '5px'}}>
+                            The {mainReq} major is not supported yet. If you would like to request it, let us know&nbsp;
+                            <a href="https://docs.google.com/forms/d/e/1FAIpQLSe0s9SDBLDI24fHzb2hwNQu93BaSQjEKVMKtZsc7nM55px8Lg/viewform">here</a>.
+                          </div>
+                          <div style={{padding: '5px'}}>In the mean time, feel free to track your AB degree requirements below.</div>
+                        </TreeView>);
+              }
               let finished = ''
               if((mainReq['min_needed'] === 0 && mainReq['count'] >= 0) ||
                 (mainReq['min_needed'] > 0 && mainReq['count'] >= mainReq['min_needed']))

--- a/frontend/src/Search.js
+++ b/frontend/src/Search.js
@@ -93,29 +93,38 @@ function renderRequirements(){
           });
           ReactDOM.render(
            data.map((mainReq, index)=>{
-              if(!(typeof mainReq === "object")) {
-                let mainReqLabel = <div className='reqLabel'
-                                    title={'<span>' + mainReq + '</span>'}>
-                                      <div className='my-arrow root-arrow'></div>
-                                      {mainReq}
-                                   </div>
-                return (<TreeView key={index} itemClassName={"tree-root"} childrenClassName="tree-sub-reqs" nodeLabel={mainReqLabel}>
-                          <div style={{padding: '5px'}}>
-                            The {mainReq} major is not supported yet. If you would like to request it, let us know&nbsp;
-                            <a href="https://docs.google.com/forms/d/e/1FAIpQLSe0s9SDBLDI24fHzb2hwNQu93BaSQjEKVMKtZsc7nM55px8Lg/viewform">here</a>.
-                          </div>
-                          <div style={{padding: '5px'}}>In the mean time, feel free to track your AB degree requirements below.</div>
-                        </TreeView>);
+              var name;
+              var content;
+              var finished = '';
+
+              // major is supported
+              if(typeof mainReq === "object") {
+                name = mainReq.name;
+                content = populateReqTree(mainReq);
+                if ((mainReq['min_needed'] === 0 && mainReq['count'] >= 0) ||
+                  (mainReq['min_needed'] > 0 && mainReq['count'] >= mainReq['min_needed']))
+                    finished='req-done';
               }
-              let finished = ''
-              if((mainReq['min_needed'] === 0 && mainReq['count'] >= 0) ||
-                (mainReq['min_needed'] > 0 && mainReq['count'] >= mainReq['min_needed']))
-                  finished='req-done';
+              // major is not supported yet
+              else {
+                name = mainReq;
+                content = <div>
+                            <p style={{padding: '5px'}}>
+                              The {name} major is not supported yet. If you would like to request it, let us know <a href="https://goo.gl/forms/pKxjmubIOSCOeR8L2" target="_blank">here</a>.
+                            </p>
+                            <p style={{padding: '5px'}}>In the meantime, you can track your AB degree requirements below.
+                            </p>
+                          </div>;
+              }
+
+              // render requirements
               let mainReqLabel = <span>
                                     <div className='my-arrow root-arrow'></div>
-                                    {mainReq.name}
+                                    {name}
                                  </span>
-              return <TreeView key={index} itemClassName={"tree-root " + finished} childrenClassName="tree-sub-reqs" nodeLabel={mainReqLabel}>{populateReqTree(mainReq)}</TreeView>
+              return <TreeView key={index} itemClassName={"tree-root " + finished} childrenClassName="tree-sub-reqs" nodeLabel={mainReqLabel}>
+                        {content}
+                      </TreeView>
             }),
             document.getElementById('requirements')
           );


### PR DESCRIPTION
- displays a friendly message
- links the user to the major support request form
- adds back the top level tree node so that it both allows the user to collapse the message if they prefer and has a more consistent feel

![image](https://user-images.githubusercontent.com/9757500/45342979-827b9500-b56d-11e8-8683-d3b4da68c64f.png)

Resolves: #70 