### PR TITLE
Fix bug where requirements won't update if the request url is too long

### DIFF
--- a/frontend/src/components/Schedule.js
+++ b/frontend/src/components/Schedule.js
@@ -130,7 +130,7 @@ export default class Schedule extends Component {
 
   render() {
     let years = this.state.years;
-    if (this.props.schedule && years) {
+    if (years) {
       return (
         <table id="semesters">
           <thead className="semester-header">

--- a/tigerpath/urls.py
+++ b/tigerpath/urls.py
@@ -20,4 +20,5 @@ urlpatterns = [
     path('api/v1/get_requirements/', views.get_requirements, name='get_requirements'),
     path('api/v1/get_req_courses/<req_path>', views.get_req_courses, name='get_req_courses'),
     path('api/v1/get_profile/', views.get_profile, name='get_profile'),
+    path('api/v1/update_schedule_and_get_requirements/', views.update_schedule_and_get_requirements, name='update_schedule_and_get_requirements'),
 ]

--- a/tigerpath/views.py
+++ b/tigerpath/views.py
@@ -248,10 +248,7 @@ def get_schedule(request):
 @login_required
 def get_requirements(request):
     curr_user = request.user.profile
-
-    schedule = ujson.loads(request.GET.get('schedule', '[]'))
-    if not schedule:
-        schedule = populate_user_schedule(curr_user.user_schedule)
+    schedule = populate_user_schedule(curr_user.user_schedule)
 
     requirements = []
     if curr_user.major:
@@ -262,6 +259,11 @@ def get_requirements(request):
             requirements.append(curr_user.major.name)
         requirements.append(check_degree(curr_user.major.degree, schedule, settings.ACTIVE_YEAR))
     return HttpResponse(ujson.dumps(requirements, ensure_ascii=False), content_type='application/json')
+
+@login_required
+def update_schedule_and_get_requirements(request):
+    update_schedule(request)
+    return get_requirements(request)
 
 @login_required
 def get_profile(request):


### PR DESCRIPTION
Fixes a major user-reported bug where the requirements wouldn't update in real-time; they would only update after you refresh. This was because for long schedules, there would be a 400 Bad Request, since the url would be too long with the schedule query parameter.

This PR removes the query parameter that was used to send the schedule to `get_requirements`. Instead, it adds a new API endpoint `update_schedule_and_get_requirements` that maintains the same relative speed while making sure that the request doesn't fail. This endpoint sends the schedule via a POST request instead of a GET request, which means that the schedule is no longer part of the URL.