### PR TITLE
Temporary workaround for registrar missing F2020 courses

### DIFF
--- a/frontend/src/Popover.js
+++ b/frontend/src/Popover.js
@@ -38,7 +38,14 @@ export function addPopover(course, courseKey, semIndex) {
   let courseSemList = course["semester_list"];
   if (courseSemList && courseSemList.length > 0) {
     let termCode = convertSemToTermCode(courseSemList[courseSemList.length - 1]);
-    let courseInfoLink = BASE_COURSE_OFFERINGS_URL + "?courseid=" + courseId + "&term=" + termCode;
+    // ****** TEMPORARY WORKAROUND FOR REGISTRAR MISSING F2020 COURSES ****** //
+    // revert this after July 20, 2020. See PR #338
+    let modified_termCode = termCode;
+    if (modified_termCode === "1212") {
+      modified_termCode = "1202"
+    }
+    let courseInfoLink = BASE_COURSE_OFFERINGS_URL + "?courseid=" + courseId + "&term=" + modified_termCode;
+    // ********************************************************************** //
     let courseEvalLink = BASE_COURSE_EVAL_URL + "?terminfo=" + termCode + "&courseinfo=" + courseId;
     
     content += "<div className='search-card-links'>"

--- a/frontend/src/components/SearchCard.js
+++ b/frontend/src/components/SearchCard.js
@@ -67,7 +67,14 @@ export default class SearchCard extends Component {
     let courseSemList = course["semester_list"];
     let termCode = this.convertSemToTermCode(courseSemList[courseSemList.length - 1]);
 
-    let courseInfoLink = `${BASE_COURSE_OFFERINGS_URL}?courseid=${courseId}&term=${termCode}`;
+    // ****** TEMPORARY WORKAROUND FOR REGISTRAR MISSING F2020 COURSES ****** //
+    // revert this after July 20, 2020. See PR #338
+    let modified_termCode = termCode;
+    if (modified_termCode === "1212") {
+      modified_termCode = "1202"
+    }
+    let courseInfoLink = `${BASE_COURSE_OFFERINGS_URL}?courseid=${courseId}&term=${modified_termCode}`;
+    // ********************************************************************** //
     let courseEvalLink = `${BASE_COURSE_EVAL_URL}?terminfo=${termCode}&courseinfo=${courseId}`;
     let prevOfferedSemList = this.getPrevOfferedSemList(courseSemList);
 


### PR DESCRIPTION
The registrar currently does not have course offerings available for F2020 courses, as they've been [taken down](https://registrar.princeton.edu/course-offerings/course-details?courseid=001381&term=1212) until July 20, which means that the course info icon for most courses leads to an empty banner on the registrar's site.

This is a temporary workaround which redirects those course's info links to the F2019 page instead, if it exists.

**** Revert this after July 20, 2020, or whenever the registrar's F2020 course webpages come back up. ****