### PR TITLE
Link course info to PrincetonCourses.com  instead of registrar's website

### DIFF
--- a/frontend/src/Popover.js
+++ b/frontend/src/Popover.js
@@ -2,8 +2,7 @@ import $ from 'jquery';
 import { getSemesterType, isFallSemester, isSpringSemester, convertSemToTermCode } from 'utils/SemesterUtils';
 
 // TODO: refactor from here and SearchCard.js
-const BASE_COURSE_OFFERINGS_URL = 'https://registrar.princeton.edu/course-offerings/course_details.xml';
-const BASE_COURSE_EVAL_URL = 'https://reg-captiva.princeton.edu/chart/index.php';
+const BASE_COURSE_OFFERINGS_URL = 'https://www.princetoncourses.com/course/';
 
 export function addPopover(course, courseKey, semIndex) {
   let courseName = course['name'];
@@ -38,16 +37,12 @@ export function addPopover(course, courseKey, semIndex) {
   let courseSemList = course["semester_list"];
   if (courseSemList && courseSemList.length > 0) {
     let termCode = convertSemToTermCode(courseSemList[courseSemList.length - 1]);
-    let courseInfoLink = BASE_COURSE_OFFERINGS_URL + "?courseid=" + courseId + "&term=" + termCode;
-    let courseEvalLink = BASE_COURSE_EVAL_URL + "?terminfo=" + termCode + "&courseinfo=" + courseId;
-    
+    let courseInfoLink = BASE_COURSE_OFFERINGS_URL + termCode + courseId;
+
     content += "<div className='search-card-links'>"
     content += "<a href=" + courseInfoLink + " target='_blank' rel='noopener noreferrer'> "
     content += "<i class='fas fa-info-circle fa-lg fa-fw course-info'></i>"
     content += "</a> "
-    content += "<a href=" + courseEvalLink + " target='_blank' rel='noopener noreferrer'>"
-    content += "<i class='fas fa-chart-bar fa-lg fa-fw course-eval' />"
-    content += "</a>"
     content += "</div>"
   }
 

--- a/frontend/src/components/SearchCard.js
+++ b/frontend/src/components/SearchCard.js
@@ -3,8 +3,7 @@ import CourseCard from 'components/CourseCard';
 import { Draggable } from 'react-beautiful-dnd';
 
 const RADIX = 10;
-const BASE_COURSE_OFFERINGS_URL = 'https://registrar.princeton.edu/course-offerings/course_details.xml';
-const BASE_COURSE_EVAL_URL = 'https://reg-captiva.princeton.edu/chart/index.php';
+const BASE_COURSE_OFFERINGS_URL = 'https://www.princetoncourses.com/course/';
 
 export default class SearchCard extends Component {
   /* Helper function to convert a semester into readable form */
@@ -67,8 +66,7 @@ export default class SearchCard extends Component {
     let courseSemList = course["semester_list"];
     let termCode = this.convertSemToTermCode(courseSemList[courseSemList.length - 1]);
 
-    let courseInfoLink = `${BASE_COURSE_OFFERINGS_URL}?courseid=${courseId}&term=${termCode}`;
-    let courseEvalLink = `${BASE_COURSE_EVAL_URL}?terminfo=${termCode}&courseinfo=${courseId}`;
+    let courseInfoLink = `${BASE_COURSE_OFFERINGS_URL}${termCode}${courseId}`;
     let prevOfferedSemList = this.getPrevOfferedSemList(courseSemList);
 
     return (
@@ -85,9 +83,6 @@ export default class SearchCard extends Component {
             <div className="search-card-links">
               <a href={courseInfoLink} target="_blank" rel="noopener noreferrer">
                 <i className="fas fa-info-circle fa-lg fa-fw course-info" />
-              </a>
-              <a href={courseEvalLink} target="_blank" rel="noopener noreferrer">
-                <i className="fas fa-chart-bar fa-lg fa-fw course-eval" />
               </a>
             </div>
           </div>


### PR DESCRIPTION
The registrar doesn't have Fall 2020 course offerings available, since they have been taken down until July 20.
Because of this, causing it so that the course info icons which normally link to the registrar's page for a course now lead to an empty page.

This links instead to the course webpage at [Princeton Courses](https://www.princetoncourses.com/), a USG TigerApp.

This an alternative to #338