### PR TITLE
Fix bug where search results move when you start dragging a course

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -104,7 +104,7 @@ export default class App extends Component {
     let destCourseIndex = result.destination.index;
     let sourceCourseIndex = result.source.index;
 
-    if (result.source.droppableId === 'search-results') {
+    if (result.source.droppableId.includes('search-result-droppable')) {
       // moving course from search results to schedule
       let searchResultsCourse = searchResults[sourceCourseIndex];
       let course = {};

--- a/frontend/src/components/CourseCard.js
+++ b/frontend/src/components/CourseCard.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import $ from 'jquery';
+import { Draggable } from 'react-beautiful-dnd';
+import { EXTERNAL_CREDITS_SEMESTER_INDEX } from 'utils/SemesterUtils';
 
 export default class CourseCard extends Component {
   removeCourse = () => {
@@ -7,33 +9,40 @@ export default class CourseCard extends Component {
     $(`#${this.props.courseKey}`).popover('hide');
   };
 
-  getClassNames = () => {
+  getClassNames = (isDragging) => {
     let classNames = [];
     classNames.push('course-card');
     classNames.push(this.props.course['semester']);
-    if (this.props.isDragging) classNames.push('course-card-shadow');
-    if (this.props.isPlaceholder) classNames.push('placeholder-course');
+    if (isDragging) classNames.push('course-card-shadow');
     return classNames.join(' ');
   };
 
   render() {
-    let course = this.props.course;
+    let { course, courseKey, courseIndex, semIndex } = this.props;
     return (
       <div className="unbreakable">
-        <div
-          id={this.props.courseKey}
-          title={course['name']}
-          className={this.getClassNames()}
-          ref={this.props.innerRef}
-          {...this.props.draggable}
-          {...this.props.dragHandle}
+        <Draggable
+          draggableId={courseKey}
+          index={courseIndex}
+          isDragDisabled={semIndex === EXTERNAL_CREDITS_SEMESTER_INDEX}
         >
-          <div className="course-name">{course['name']}</div>
-          <i
-            className="fas fa-times-circle delete-course"
-            onClick={this.removeCourse}
-          />
-        </div>
+          {(provided, snapshot) => (
+            <div
+              ref={provided.innerRef}
+              id={courseKey}
+              title={course['name']}
+              className={this.getClassNames(snapshot.isDragging)}
+              {...provided.draggableProps}
+              {...provided.dragHandleProps}
+            >
+              <div className="course-name">{course['name']}</div>
+              <i
+                className="fas fa-times-circle delete-course"
+                onClick={this.removeCourse}
+              />
+            </div>
+          )}
+        </Draggable>
         <div className="search-card-info print-only">{course['title']}</div>
       </div>
     );

--- a/frontend/src/components/Search.js
+++ b/frontend/src/components/Search.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import $ from 'jquery';
 import SearchCard from 'components/SearchCard';
-import { Droppable } from 'react-beautiful-dnd';
 
 export default class Search extends Component {
   constructor(props) {
@@ -65,29 +64,19 @@ export default class Search extends Component {
           <span>Search Results</span>
           <i id="spinner" className="fas fa-circle-notch fa-spin"></i>
         </div>
-        <Droppable droppableId="search-results" isDropDisabled={true}>
-          {(provided, snapshot) => (
-            <React.Fragment>
-              <div
-                id="display-courses"
-                ref={provided.innerRef}
-                {...provided.droppableProps}
-              >
-                {this.props.searchResults.map((course, courseIndex) => {
-                  let courseKey = `course-card-${course['semester']}-search-${courseIndex}`;
-                  return (
-                    <SearchCard
-                      key={courseKey}
-                      courseKey={courseKey}
-                      index={courseIndex}
-                      course={course}
-                    />
-                  );
-                })}
-              </div>
-            </React.Fragment>
-          )}
-        </Droppable>
+        <div id="display-courses">
+          {this.props.searchResults.map((course, courseIndex) => {
+            const courseKey = `course-card-${course['semester']}-search-${courseIndex}`;
+            return (
+              <SearchCard
+                key={courseKey}
+                courseKey={courseKey}
+                index={courseIndex}
+                course={course}
+              />
+            );
+          })}
+        </div>
       </React.Fragment>
     );
   }

--- a/frontend/src/components/SearchCard.js
+++ b/frontend/src/components/SearchCard.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
-import CourseCard from 'components/CourseCard';
-import { Draggable } from 'react-beautiful-dnd';
+import SearchCourseCard from './SearchCourseCard';
 
 const RADIX = 10;
 const BASE_COURSE_OFFERINGS_URL = 'https://www.princetoncourses.com/course/';
@@ -51,31 +50,6 @@ export default class SearchCard extends Component {
     return code;
   };
 
-  courseCard = (provided, snapshot) => {
-    let course = this.props.course;
-    let courseKey = this.props.courseKey;
-    return (
-      <React.Fragment>
-        <CourseCard
-          innerRef={provided.innerRef}
-          draggable={provided.draggableProps}
-          dragHandle={provided.dragHandleProps}
-          course={course}
-          courseKey={courseKey}
-          isDragging={snapshot.isDragging}
-        />
-        {snapshot.isDragging && (
-          <CourseCard
-            course={course}
-            courseKey={`${courseKey}-placeholder`}
-            isPlaceholder={true}
-            isDragging={false}
-          />
-        )}
-      </React.Fragment>
-    );
-  };
-
   render() {
     let course = this.props.course;
     let courseId = course['id'];
@@ -89,13 +63,12 @@ export default class SearchCard extends Component {
 
     return (
       <div className={`search-card ${course['semester']}`}>
-        <React.Fragment>
-          <Draggable
-            draggableId={this.props.courseKey}
-            index={this.props.index}
-          >
-            {(provided, snapshot) => this.courseCard(provided, snapshot)}
-          </Draggable>
+        <>
+          <SearchCourseCard
+            course={course}
+            courseKey={this.props.courseKey}
+            courseIndex={this.props.index}
+          />
           <div className="search-card-info">
             <div>
               <div className="course-title">{course['title']}</div>
@@ -111,7 +84,7 @@ export default class SearchCard extends Component {
               </a>
             </div>
           </div>
-        </React.Fragment>
+        </>
       </div>
     );
   }

--- a/frontend/src/components/SearchCourseCard.js
+++ b/frontend/src/components/SearchCourseCard.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Draggable, Droppable } from 'react-beautiful-dnd';
+import styled, { css } from 'styled-components';
+
+const SearchCourseCardStyled = styled.div`
+  ${({ isBeingDragged }) =>
+    isBeingDragged &&
+    css`
+      cursor: grabbing !important;
+      box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25),
+        0 10px 10px rgba(0, 0, 0, 0.22);
+      z-index: 1;
+    `}
+`;
+
+const PlaceholderCourse = styled.div`
+  & ~ [data-rbd-placeholder-context-id] {
+    display: none !important;
+  }
+`;
+
+const SearchCourseCard = (props) => {
+  const { courseIndex, courseKey, course } = props;
+
+  return (
+    <Droppable
+      droppableId={`search-result-droppable-${courseKey}`}
+      isDropDisabled={true}
+    >
+      {(provided, snapshot) => (
+        <div ref={provided.innerRef} {...provided.droppableProps}>
+          <Draggable draggableId={courseKey} index={courseIndex}>
+            {(provided, snapshot) => (
+              <>
+                <SearchCourseCardStyled
+                  ref={provided.innerRef}
+                  id={courseKey}
+                  title={course['name']}
+                  className={`course-card ${course['semester']}`}
+                  isBeingDragged={snapshot.isDragging}
+                  {...provided.draggableProps}
+                  {...provided.dragHandleProps}
+                >
+                  <div className="course-name">{course['name']}</div>
+                </SearchCourseCardStyled>
+                {snapshot.isDragging && (
+                  <PlaceholderCourse
+                    id={`${courseKey}-placeholder`}
+                    className={`course-card ${course['semester']}`}
+                  >
+                    <div className="course-name">{course['name']}</div>
+                  </PlaceholderCourse>
+                )}
+              </>
+            )}
+          </Draggable>
+          {provided.placeholder}
+        </div>
+      )}
+    </Droppable>
+  );
+};
+
+export default SearchCourseCard;

--- a/frontend/src/components/Semester.js
+++ b/frontend/src/components/Semester.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import CourseCard from 'components/CourseCard';
-import { Droppable, Draggable } from 'react-beautiful-dnd';
+import { Droppable } from 'react-beautiful-dnd';
 import styled from 'styled-components';
 import {
   SEMESTER_TYPE,
@@ -74,26 +74,14 @@ export default class Semester extends Component {
         {semester[semIndex].map((course, courseIndex) => {
           let courseKey = `course-card-${course['semester']}-${semIndex}-${courseIndex}`;
           return (
-            <Draggable
+            <CourseCard
               key={courseKey}
-              draggableId={courseKey}
-              index={courseIndex}
-              isDragDisabled={semIndex === EXTERNAL_CREDITS_SEMESTER_INDEX}
-            >
-              {(provided, snapshot) => (
-                <CourseCard
-                  innerRef={provided.innerRef}
-                  draggable={provided.draggableProps}
-                  dragHandle={provided.dragHandleProps}
-                  course={course}
-                  courseKey={courseKey}
-                  isDragging={snapshot.isDragging}
-                  onCourseRemove={this.removeCourse}
-                  semIndex={semIndex}
-                  courseIndex={courseIndex}
-                />
-              )}
-            </Draggable>
+              course={course}
+              courseKey={courseKey}
+              onCourseRemove={this.removeCourse}
+              semIndex={semIndex}
+              courseIndex={courseIndex}
+            />
           );
         })}
       </React.Fragment>

--- a/frontend/src/styles/Courses.css
+++ b/frontend/src/styles/Courses.css
@@ -128,23 +128,12 @@
   z-index: 1;
 }
 
-.course-card:hover:active, .course-card-shadow {
-  cursor: grabbing;
-  box-shadow: 0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22);
-  z-index: 1;
-}
-
-/* don't show react-beautiful-dnd's placeholder in search results */
-.placeholder-course + div {
-  display: none !important;
-}
-
 .course-info:hover, .course-eval:hover {
   color: #5a6268;
 }
 
 /* add delete button on course hover in semesters */
-.semester .course-card:hover .delete-course {
+.course-card:hover .delete-course {
   display: block;
 }
 


### PR DESCRIPTION
There was a bug before where the course cards in the search results would move around when you start dragging a course:

![before](https://tmp.f8.n0.cdn.getcloudapp.com/items/rRulxwZW/Screen%20Recording%202020-07-15%20at%2005.10.11.74%20PM.gif?v=9e396c016ec7bb95a89f16f43a995e1c)

This PR fixes the bug:

![after](https://tmp.f8.n0.cdn.getcloudapp.com/items/2Nu5ZJL4/Screen%20Recording%202020-07-15%20at%2005.09.38.80%20PM.gif?v=0562864974d062abb6190dfd9f626192)

The reason why it wasn't working before was because react-beautiful-dnd (the drag and drop library we use) expects draggable items to be next to each other, but our search results are not formatted like that (there are non-draggable elements such as the course title in between).

This PR essentially makes it so that each search card is a separate droppable, instead of the entire search results being one big droppable.

Painfully split out from https://github.com/TigerPathApp/tigerpath/pull/323