### PR TITLE
Fix find satisfying courses button in req popover

### DIFF
--- a/frontend/src/Popover.js
+++ b/frontend/src/Popover.js
@@ -66,7 +66,12 @@ export function addPopover(course, courseKey, semIndex) {
 
   // Show the popover when it's hovered over
   courseElement
-    .popover({ trigger: 'manual', html: true, animation: true })
+    .popover({
+      trigger: 'manual',
+      html: true,
+      animation: true,
+      sanitize: false,
+    })
     .on('mouseenter', () => {
       courseElement.popover('show');
       $('.popover').on('mouseleave', () => {

--- a/frontend/src/components/Requirements.js
+++ b/frontend/src/components/Requirements.js
@@ -71,6 +71,7 @@ export default class Requirements extends Component {
           boundary: 'viewport',
           template:
             '<div class="popover req-popover" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>',
+          sanitize: false,
         })
         .on('mouseenter', () => {
           reqLabelElement.popover('show');


### PR DESCRIPTION
So apparently there was a breaking change in Bootstrap where they're now sanitizing all of the buttons in popover content: https://github.com/twbs/bootstrap/issues/28290#issuecomment-464428567

I had to add `sanitize: false` in order to work around this. This isn't the greatest but is hopefully not a big deal since we'll be moving over to a different popover library soon.