### PR TITLE
Fix optional unproductive requirements not being checked

### DIFF
--- a/tigerpath/majors_and_certificates/majors/ECO_2018.json
+++ b/tigerpath/majors_and_certificates/majors/ECO_2018.json
@@ -217,8 +217,7 @@
     },
     {
       "name": "Optional Tracks",
-      # the following line is a hack to allow for an unproductive requirement that still gets checked. See discussion at PR #296
-      "max_counted": 0.000000000001,
+      "max_counted": 0,
       "min_needed": 0,
       "explanation": null,
       "req_list": [

--- a/tigerpath/majors_and_certificates/majors/POL_2018.json
+++ b/tigerpath/majors_and_certificates/majors/POL_2018.json
@@ -426,8 +426,7 @@
     },
     {
       "name": "Optional Tracks",
-      # the following line is a hack to allow for an unproductive requirement that still gets checked. See discussion at PR #296
-      "max_counted": 0.000000000001,
+      "max_counted": 0,
       "min_needed": 0,
       "explanation": "All students who declare their concentration in Politics are eligible to pursue one of the three tracks and should inform the Undergraduate Program Manager of their intention to pursue a program upon declaring the concentration in April of their sophomore year, and no later than February 1 of their junior year. The tracks provide additional guidance for structuring the program of study as a Politics concentrator, but students are not required to select a track to graduate with a degree in Politics. Students who pursue a program will still need to fulfill the requirements of a Politics concentrator. Courses may simultaneously fulfill both the program requirements and the Politics concentration requirements.",
       "double_counting_allowed": true,

--- a/tigerpath/majors_and_certificates/scripts/verifier.py
+++ b/tigerpath/majors_and_certificates/scripts/verifier.py
@@ -422,8 +422,6 @@ def _assign_settled_courses_to_reqs(req, courses):
     old_deficit = req["min_needed"] - req["count"]
     if (req["max_counted"] != None):
         old_available = req["max_counted"] - req["count"]
-        if old_available <= 0: # already saturated, nothing to update
-            return 0
     was_satisfied = (old_deficit <= 0)
     newly_satisfied = 0
     if "req_list" in req: # recursively check subrequirements
@@ -448,7 +446,7 @@ def _assign_settled_courses_to_reqs(req, courses):
         if req["max_counted"] == None: # unlimited
             return newly_satisfied
         else:
-            return min(old_available,newly_satisfied) # cut off at old_available
+            return min(old_available, newly_satisfied) # cut off at old_available
     else: # requirement still not satisfied
         return 0
 


### PR DESCRIPTION
Previously, the verifier was making the decision not to go down a subtree if it couldn't possibly contribute to completing the major.

However, we have recently started adding requirements that are, in a sense, just for the user's information, and which do not actually contribute to completing the major, such as the optional tracks in the [ECO](https://github.com/TigerPathApp/tigerpath/pull/296#discussion_r453366107) and [POL](https://github.com/TigerPathApp/tigerpath/pull/311) majors.
However, these requirements were not then checked by the verifier without making use of a hack.

This pull request therefore allows the verifier do go down any and all subtrees, even unproductive ones, which lets these optional requirements be checked.
It doesn't change how the count is computed though, so such requirements should still not contribute to completing the major.
It also removes the hack code from the two majors that had it.

This is a small change, but since it is a change in the verifier's logic, which can occasionally have unexpected consequences for other requirement structures, it's probably best to thoroughly test it. I don't expect there to be too many issues, though, since it's a pretty precise change that should only apply to those specific cases.

Closes #353