### PR TITLE
Make course colors colorblind-safe

### DIFF
--- a/frontend/src/components/Semester.js
+++ b/frontend/src/components/Semester.js
@@ -20,7 +20,7 @@ const SemesterHeader = styled(({ semesterType, ...rest }) => <div {...rest} />)`
   color: ${({ theme, semesterType }) => {
     switch (semesterType) {
       case SEMESTER_TYPE.DEFAULT:
-        return `${theme.black}`;
+        return `${theme.ECHeaderTextColor}`;
       case SEMESTER_TYPE.FALL_SEM:
         return '#ffffff';
       case SEMESTER_TYPE.SPRING_SEM:
@@ -42,7 +42,7 @@ const SemesterHeader = styled(({ semesterType, ...rest }) => <div {...rest} />)`
       case SEMESTER_TYPE.SPRING_SEM:
         return `${theme.springSemHeaderColor}`;
       default:
-        return `${theme.darkOrange}`;
+        return `${theme.ECHeaderBackgroundColor}`;
     }
   }};
 `;

--- a/frontend/src/components/Semester.js
+++ b/frontend/src/components/Semester.js
@@ -17,7 +17,19 @@ const SEMESTER_BODY_COLOR = Object.freeze({
 });
 
 const SemesterHeader = styled(({ semesterType, ...rest }) => <div {...rest} />)`
-  color: #ffffff;
+  color: ${({ theme, semesterType }) => {
+    switch (semesterType) {
+      case SEMESTER_TYPE.DEFAULT:
+        return `${theme.black}`;
+      case SEMESTER_TYPE.FALL_SEM:
+        return '#ffffff';
+      case SEMESTER_TYPE.SPRING_SEM:
+        return '#ffffff';
+      default:
+        return '#ffffff';
+    }
+  }};
+
   text-align: center;
   font-size: large;
   border-radius: 2px 2px 0 0;

--- a/frontend/src/components/Semester.js
+++ b/frontend/src/components/Semester.js
@@ -17,18 +17,7 @@ const SEMESTER_BODY_COLOR = Object.freeze({
 });
 
 const SemesterHeader = styled(({ semesterType, ...rest }) => <div {...rest} />)`
-  color: ${({ theme, semesterType }) => {
-    switch (semesterType) {
-      case SEMESTER_TYPE.DEFAULT:
-        return `${theme.ECHeaderTextColor}`;
-      case SEMESTER_TYPE.FALL_SEM:
-        return '#ffffff';
-      case SEMESTER_TYPE.SPRING_SEM:
-        return '#ffffff';
-      default:
-        return '#ffffff';
-    }
-  }};
+  color: #ffffff;
 
   text-align: center;
   font-size: large;

--- a/frontend/src/components/Semester.js
+++ b/frontend/src/components/Semester.js
@@ -18,7 +18,6 @@ const SEMESTER_BODY_COLOR = Object.freeze({
 
 const SemesterHeader = styled(({ semesterType, ...rest }) => <div {...rest} />)`
   color: #ffffff;
-
   text-align: center;
   font-size: large;
   border-radius: 2px 2px 0 0;
@@ -31,7 +30,7 @@ const SemesterHeader = styled(({ semesterType, ...rest }) => <div {...rest} />)`
       case SEMESTER_TYPE.SPRING_SEM:
         return `${theme.springSemHeaderColor}`;
       default:
-        return `${theme.ECHeaderBackgroundColor}`;
+        return `${theme.ECHeaderColor}`;
     }
   }};
 `;

--- a/frontend/src/styles/Courses.css
+++ b/frontend/src/styles/Courses.css
@@ -109,8 +109,8 @@
 }
 
 .course-card.external {
-  background-color: #f3d9be;
-  color: #753a00;
+  background-color: #f9d4cd;
+  color: #543129;
 }
 
 .course-card .course-name {

--- a/frontend/src/styles/theme.js
+++ b/frontend/src/styles/theme.js
@@ -1,6 +1,4 @@
 export const TIGERPATH_THEME = {
-  ECHeaderBackgroundColor: '#ec775f',
-
   /* Navigation colors */
   darkGreyText: '#555555',
   lightGrey: '#6c757d',
@@ -12,6 +10,7 @@ export const TIGERPATH_THEME = {
   redSemBody: '#ffc0cb',
 
   /* Should change description in tutorial.js whenever these colors are modified. */
+  ECHeaderColor: '#ec775f',
   fallSemHeaderColor: '#ad79d4',
   springSemHeaderColor: '#3aaed4',
 };

--- a/frontend/src/styles/theme.js
+++ b/frontend/src/styles/theme.js
@@ -1,5 +1,6 @@
 export const TIGERPATH_THEME = {
-  darkOrange: '#e49f58',
+  darkOrange: '#f9d4cd',
+  black: '#000000',
 
   /* Navigation colors */
   darkGreyText: '#555555',

--- a/frontend/src/styles/theme.js
+++ b/frontend/src/styles/theme.js
@@ -1,6 +1,6 @@
 export const TIGERPATH_THEME = {
-  darkOrange: '#f9d4cd',
-  black: '#000000',
+  ECHeaderBackgroundColor: '#f9d4cd',
+  ECHeaderTextColor: '#543129',
 
   /* Navigation colors */
   darkGreyText: '#555555',

--- a/frontend/src/styles/theme.js
+++ b/frontend/src/styles/theme.js
@@ -1,6 +1,5 @@
 export const TIGERPATH_THEME = {
-  ECHeaderBackgroundColor: '#f9d4cd',
-  ECHeaderTextColor: '#543129',
+  ECHeaderBackgroundColor: '#ec775f',
 
   /* Navigation colors */
   darkGreyText: '#555555',


### PR DESCRIPTION
Changed courses colors as requested by @churichard. Fixes #265.

[Chroma.js](https://gka.github.io/palettes/#/3|s|eaccff,c4e3ed,f9d4cd|ffffe0,ff005e,93003a|0|0) verifies this color palette as being colorblind-safe.

![image](https://user-images.githubusercontent.com/23485492/88600936-68ea7600-d03d-11ea-8022-7648855bfbd0.png)
