### PR TITLE
Enforce no_req not contributing to requirement counts

### DIFF
--- a/tigerpath/majors_and_certificates/scripts/verifier.py
+++ b/tigerpath/majors_and_certificates/scripts/verifier.py
@@ -324,6 +324,10 @@ def _init_req_fields(req):
     req["count"] = 0
     if ("name" not in req) or (req["name"] == '') or (req["name"] == None):
         req["name"] = None
+    if "no_req" in req:  # enforce that no_req cannot require a non-zero count
+        req["no_req"] = None  # ignore the contents of a no_req
+        req["min_needed"] = None
+        req["max_counted"] = None
     if "min_needed" not in req or req["min_needed"] == None:
         if "type" in req: # check for root
             req["min_needed"] = "ALL"


### PR DESCRIPTION
This enforces that a requirement containing a `no_req` (that is, an empty, unenforceable requirement) will have its `min_needed` and `max_counted` fields ignored.

This prevents it from accidentally being counted as part of the set of requirements which must be satisfied to complete the major (which then makes the major impossible to complete).

This corrects a developer error when encoding such a `no_req` requirement, but it also makes it easier to switch back and forth between `no_req` and an actual requirement during development and testing.

This would also simplify some of the encodings of class year differences once #368 is merged in.