### PR TITLE
Use student class years instead of hardcoded 2018

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -147,12 +147,3 @@ CAS_LOGOUT_COMPLETELY = False
 # For example, the Fall 2016 term is 1172 - the ending year is 2017.
 # Similarly, the Spring 2017 term is 1174 - the ending year is 2017.
 ACTIVE_TERMS = [1162, 1164, 1172, 1174, 1182, 1184, 1192, 1194, 1202]
-
-# NOTE: [Requirements sets for different class years]
-# The ACTIVE_YEAR is a placeholder for a yet-to-be-implemented feature that
-# will be used to decide between different sets of requirements for different
-# class years.
-# As this is not yet fully implemented, there is currently only one set
-# of requirements, all of which are currently listed under class year 2018.
-# The active year is thus a placeholder for a future feature.
-ACTIVE_YEAR = 2018  # Do not update. Leave at 2018.

--- a/tigerpath/majors_and_certificates/scripts/verifier.py
+++ b/tigerpath/majors_and_certificates/scripts/verifier.py
@@ -27,8 +27,7 @@ def check_major(major_name, courses, year):
 
     :param major_name: the name of the major
     :param courses: a list of course-listings
-    :param year: the year for which to pull the requirements \
-    (by spring semester, so 2018 means 2017-2018 school year)
+    :param year: the user's class year for which to read the requirements
     :type major_name: string
     :type courses: 2D array
     :type year: int
@@ -43,7 +42,7 @@ def check_major(major_name, courses, year):
     if (major_name not in university_info.AB_CONCENTRATIONS
             and major_name not in university_info.BSE_CONCENTRATIONS):
         raise ValueError("Major code not recognized.")
-    major_filename = "%s_%d.json" % (major_name, year)
+    major_filename = "%s_%d.json" % (major_name, 2018)  # files are still named as AAA_2018.json for now
     major_filepath = os.path.join(_get_dir_path(), MAJORS_LOCATION, major_filename)
     return check_requirements(major_filepath, courses, year)
 
@@ -54,8 +53,7 @@ def check_degree(degree_name, courses, year):
 
     :param degree_name: the name of the degree
     :param courses: a list of course-listings
-    :param year: the year for which to pull the requirements \
-    (by spring semester, so 2018 means 2017-2018 school year)
+    :param year: the user's class year for which to read the requirements
     :type degree_name: string
     :type courses: 2D array
     :type year: int
@@ -70,7 +68,7 @@ def check_degree(degree_name, courses, year):
         raise ValueError("Year is invalid.")
     if degree_name not in ["AB", "BSE"]:
         raise ValueError("Invalid degree name: %s" % degree_name)
-    degree_filename = "%s_%d.json" % (degree_name, year)
+    degree_filename = "%s_%d.json" % (degree_name, 2018)  # files are still named as AAA_2018.json for now
     degree_filepath = os.path.join(_get_dir_path(), DEGREES_LOCATION, degree_filename)
     return check_requirements(degree_filepath, courses, year)
 
@@ -84,8 +82,7 @@ def check_certificate(certificate_name, courses, year):
 
     :param certificate_name: the name of the certificate
     :param courses: a list of course-listings
-    :param year: the year for which to pull the requirements \
-    (by spring semester, so 2018 means 2017-2018 school year)
+    :param year: the user's class year for which to read the requirements
     :type certificate_name: string
     :type courses: 2D array
     :type year: int
@@ -99,7 +96,7 @@ def check_certificate(certificate_name, courses, year):
         raise ValueError("Year is invalid.")
     if (certificate_name not in university_info.CERTIFICATES):
         raise ValueError("Certificate not recognized.")
-    certificate_filename = "%s_%d.json" % (certificate_name, year)
+    certificate_filename = "%s_%d.json" % (certificate_name, 2018)  # files are still named as AAA_2018.json for now
     certificate_filepath = os.path.join(_get_dir_path(), CERTIFICATES_LOCATION, certificate_filename)
     return check_requirements(certificate_filepath, courses, year)
 
@@ -110,8 +107,7 @@ def check_requirements(req_file, courses, year):
 
     :param req_file: the name of a file containing a requirements JSON
     :param courses: a list of course-listings
-    :param year: the year for which to pull the requirements \
-    (by spring semester, so 2018 means 2017-2018 school year)
+    :param year: the user's class year for which to read the requirements
     :type req_file: string
     :type courses: 2D array
     :type year: int
@@ -122,7 +118,7 @@ def check_requirements(req_file, courses, year):
     """
     with open(req_file, 'r', encoding="utf8") as f:
         req = yaml.safe_load(f)
-    courses = _init_courses(courses, req)
+    courses = _init_courses(courses, req, year)
     req = _init_req(req, year)
     _mark_possible_reqs(req, courses)
     _assign_settled_courses_to_reqs(req, courses)
@@ -158,7 +154,7 @@ def get_courses_by_path(path):
         raise ValueError("Path malformatted.")
     if "/" in req_type or "/" in req_name:
         raise ValueError("Path malformatted.")
-    filename = "%s_%d.json" % (req_name, year)
+    filename = "%s_%d.json" % (req_name, 2018)  # files are still named as AAA_2018.json for now
     if req_type == "Major":
         if (req_name not in university_info.AB_CONCENTRATIONS and req_name not in university_info.BSE_CONCENTRATIONS):
             raise ValueError("Path malformatted.")
@@ -176,7 +172,7 @@ def get_courses_by_path(path):
     with open(req_filepath, 'r', encoding="utf8") as f:
         req = yaml.safe_load(f)
     _init_year_switch(req, year)
-    subreq = _get_req_by_path(req, path)
+    subreq = _get_req_by_path(req, path, year)
     if not subreq:
         raise ValueError("Path malformatted: " + path)
     return _get_collapsed_course_and_dist_req_sets(subreq)
@@ -187,7 +183,7 @@ def _init_req(req, year):
     _init_req_fields(req)
     _init_min_ALL(req)
     _init_double_counting_allowed(req)
-    _init_path_to(req)
+    _init_path_to(req, year)
     return req
 
 def _format_req_output(req):
@@ -276,7 +272,7 @@ def _add_course_lists_to_req(req, courses):
                             req["unsettled"].append(course["name"])
                             break
 
-def _init_courses(courses, req):
+def _init_courses(courses, req, year):
     if not courses:
         courses = DEFAULT_SCHEDULE
     else:
@@ -295,11 +291,11 @@ def _init_courses(courses, req):
                 course["settled"] = []
             elif req["type"] in ["Major", "Degree"]: # filter out irrelevant requirements from list
                 for path in course["settled"]:
-                    if not path.startswith(REQ_PATH_PREFIX % (req["type"], req["year"], req["code"])):
+                    if not path.startswith(REQ_PATH_PREFIX % (req["type"], year, req["code"])):
                         course["settled"].remove(path)
             else: # type must be "Certificate"
                 for path in course["settled"]:
-                    if not path.startswith(REQ_PATH_PREFIX % (req["type"], req["year"], req["name"])):
+                    if not path.startswith(REQ_PATH_PREFIX % (req["type"], year, req["name"])):
                         course["settled"].remove(path)
     return courses
 
@@ -434,7 +430,7 @@ def _init_double_counting_allowed(req, from_parent=False):
         for subreq in req["req_list"]:
             _init_double_counting_allowed(subreq, req["double_counting_allowed"])
 
-def _init_path_to(req):
+def _init_path_to(req, year):
     """
     Assign a path identifier to each node/subrequirement in the requirements
     tree with the properties:
@@ -444,9 +440,9 @@ def _init_path_to(req):
     """
     if "path_to" not in req: # only for root of the tree
         if req["type"] in ["Major", "Degree"]:
-            req["path_to"] = REQ_PATH_PREFIX % (req["type"],req["year"],req["code"])
+            req["path_to"] = REQ_PATH_PREFIX % (req["type"], year, req["code"])
         else: # type must be "Certificate"
-            req["path_to"] = REQ_PATH_PREFIX % (req["type"],req["year"],req["name"])
+            req["path_to"] = REQ_PATH_PREFIX % (req["type"], year, req["name"])
     if "req_list" in req:
         for i,subreq in enumerate(req["req_list"]):
             # the identifier is the req name if present, or otherwise, an identifying number
@@ -456,7 +452,7 @@ def _init_path_to(req):
             else:
                 identifier = subreq["name"]
             subreq["path_to"] = req["path_to"] + REQ_PATH_SEPARATOR + str(identifier)
-            _init_path_to(subreq)
+            _init_path_to(subreq, year)
 
 def _json_format(obj):
     import json
@@ -638,17 +634,17 @@ def _course_match(course_name, pattern):
                 return True
     return False
 
-def _get_req_by_path(req, path_to):
+def _get_req_by_path(req, path_to, year):
     """
     Returns the subrequirement of req that is pointed to by path_to
     """
     if "path_to" not in req:
-        _init_path_to(req)
+        _init_path_to(req, year)
     if req["path_to"] == path_to:
         return req
     if "req_list" in req:
         for subreq in req["req_list"]:
-            result = _get_req_by_path(subreq, path_to)
+            result = _get_req_by_path(subreq, path_to, year)
             if result:
                 return result
     return None

--- a/tigerpath/majors_and_certificates/scripts/verifier.py
+++ b/tigerpath/majors_and_certificates/scripts/verifier.py
@@ -45,7 +45,7 @@ def check_major(major_name, courses, year):
         raise ValueError("Major code not recognized.")
     major_filename = "%s_%d.json" % (major_name, year)
     major_filepath = os.path.join(_get_dir_path(), MAJORS_LOCATION, major_filename)
-    return check_requirements(major_filepath, courses)
+    return check_requirements(major_filepath, courses, year)
 
 def check_degree(degree_name, courses, year):
     """
@@ -72,7 +72,7 @@ def check_degree(degree_name, courses, year):
         raise ValueError("Invalid degree name: %s" % degree_name)
     degree_filename = "%s_%d.json" % (degree_name, year)
     degree_filepath = os.path.join(_get_dir_path(), DEGREES_LOCATION, degree_filename)
-    return check_requirements(degree_filepath, courses)
+    return check_requirements(degree_filepath, courses, year)
 
 def check_certificate(certificate_name, courses, year):
     """
@@ -101,9 +101,9 @@ def check_certificate(certificate_name, courses, year):
         raise ValueError("Certificate not recognized.")
     certificate_filename = "%s_%d.json" % (certificate_name, year)
     certificate_filepath = os.path.join(_get_dir_path(), CERTIFICATES_LOCATION, certificate_filename)
-    return check_requirements(certificate_filepath, courses)
+    return check_requirements(certificate_filepath, courses, year)
 
-def check_requirements(req_file, courses):
+def check_requirements(req_file, courses, year):
     """
     Returns information about the requirements satisfied by the courses
     given in courses.
@@ -123,7 +123,7 @@ def check_requirements(req_file, courses):
     with open(req_file, 'r', encoding="utf8") as f:
         req = yaml.safe_load(f)
     courses = _init_courses(courses, req)
-    req = _init_req(req)
+    req = _init_req(req, year)
     _mark_possible_reqs(req, courses)
     _assign_settled_courses_to_reqs(req, courses)
     _add_course_lists_to_req(req, courses)
@@ -175,13 +175,15 @@ def get_courses_by_path(path):
         raise ValueError("Path malformatted.")
     with open(req_filepath, 'r', encoding="utf8") as f:
         req = yaml.safe_load(f)
+    _init_year_switch(req, year)
     subreq = _get_req_by_path(req, path)
     if not subreq:
         raise ValueError("Path malformatted: " + path)
     return _get_collapsed_course_and_dist_req_sets(subreq)
 
-def _init_req(req):
+def _init_req(req, year):
     req = copy.deepcopy(req)
+    _init_year_switch(req, year)
     _init_req_fields(req)
     _init_min_ALL(req)
     _init_double_counting_allowed(req)
@@ -315,6 +317,65 @@ def _format_courses_output(courses):
             if len(course["settled"]) > 0: # only show if non-empty
                 output[i][j]["settled"] = course["settled"]
     return output
+
+def _parse_year_code(code, year):
+    """
+    Returns whether `year` falls in the range specified by `code`
+    """
+    if isinstance(code, int):  # explicitly specified year as an int
+        return year == code
+    if not code or code.lower() == "default":  # empty indicates default case
+        return True
+    code = code.replace(" ", "")  # strip it of spaces for processing
+    if code.startswith("<="):
+        return year <= int(code[2:])
+    elif code.startswith(">="):
+        return year >= int(code[2:])
+    elif code.startswith("<"):
+        return year < int(code[1:])
+    elif code.startswith(">"):
+        return year > int(code[1:])
+    elif code.startswith("=="):
+        return year == int(code[2:])
+    elif code.startswith("!="):
+        return year != int(code[2:])
+    elif "-" in code:  # range of years (inclusive), such as "2018-2020"
+        fr, to, *_ = code.split("-")
+        return year >= int(fr) and year <= int(to)
+    else:  # just the year is the same as ==
+        return year == int(code)
+
+def _init_year_switch(req, year):
+    """
+    Checks for any year_switch primitives and selects the right subrequirements.
+
+    Any requirement that contains a year_switch is overridden by the first
+    subrequirement of that year_switch whose year code matches the user's
+    class year.
+    Fields in req are overridden by any explicitly listed fields of the
+    overriding subrequirement, but any fields not specified by the
+    subrequirement remain as is (except the year_switch, which is removed).
+
+    If no year code matches, the requirement is unchanged and the year_switch
+    is just removed (that is, the year_switch is ignored and has no effect).
+    """
+    if "year_switch" in req:
+        newreq = {}
+        for subreq in req["year_switch"]:
+            code = subreq.get("year_code", None)  # year_code set to default
+            if _parse_year_code(code, year):
+                newreq = subreq
+                break  # stop at the first year code that matches
+        del req["year_switch"]
+        if "year_code" in newreq:
+            del newreq["year_code"]
+        req.update(newreq)  # override with the values from subreq
+    # Note that the recursive case below can always still happen even if the
+    # year_switch above was triggered, since it may have just gained a req_list
+    # from the overriding subrequirement.
+    if "req_list" in req:
+        for subreq in req["req_list"]:
+            _init_year_switch(subreq, year)
 
 def _init_req_fields(req):
     """

--- a/tigerpath/views.py
+++ b/tigerpath/views.py
@@ -1,5 +1,4 @@
 from django.shortcuts import render, redirect
-from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
@@ -292,11 +291,11 @@ def get_requirements(request):
     requirements = []
     if curr_user.major:
         if curr_user.major.supported:
-            requirements.append(check_major(curr_user.major.code, schedule, settings.ACTIVE_YEAR))
+            requirements.append(check_major(curr_user.major.code, schedule, curr_user.year))
         else:
             # appends user major name so we can display error message
             requirements.append(curr_user.major.name)
-        requirements.append(check_degree(curr_user.major.degree, schedule, settings.ACTIVE_YEAR))
+        requirements.append(check_degree(curr_user.major.degree, schedule, curr_user.year))
     return HttpResponse(ujson.dumps(requirements, ensure_ascii=False), content_type='application/json')
 
 @login_required


### PR DESCRIPTION
This passes in the student's actual class year to the verifier for use in deciding which set of requirements to use.
Previously, the value passed in was the hard-coded dummy value of 2018, because class year differences hadn't yet been implemented.

Note that this pull request does not change the requirement files themselves, so the verifier code still needs to read files named `AAA_2018.json`, which is why 2018 is still hardcoded on lines that look up the files.

This pull request is part of a stack:

- [x] #368 - Implement class year differences
- [x] #370 - **Use student class years instead of hardcoded 2018**
- [ ] #372 - Implement example class year differences for COS
- [ ] #373 - Remove hardcoded year from req file names
- [ ] #374 - Remove hardcoded year field from requirement files