### PR TITLE
[Fix] Enforce no_req not contributing to requirement counts

### DIFF
--- a/tigerpath/majors_and_certificates/scripts/verifier.py
+++ b/tigerpath/majors_and_certificates/scripts/verifier.py
@@ -326,8 +326,8 @@ def _init_req_fields(req):
         req["name"] = None
     if "no_req" in req:  # enforce that no_req cannot require a non-zero count
         req["no_req"] = None  # ignore the contents of a no_req
-        req["min_needed"] = None
-        req["max_counted"] = None
+        req["min_needed"] = 0
+        req["max_counted"] = 0
     if "min_needed" not in req or req["min_needed"] == None:
         if "type" in req: # check for root
             req["min_needed"] = "ALL"


### PR DESCRIPTION
Fixes PR #369

There was an issue with the requirement still contributing if `no_req` is present along with a `course_list`, `req_list`, or `dist_req`. This should fix it.