### PR TITLE
Equate SPI and WWS courses

### DIFF
--- a/tigerpath/majors_and_certificates/scripts/verifier.py
+++ b/tigerpath/majors_and_certificates/scripts/verifier.py
@@ -602,9 +602,14 @@ def _check_degree_progress(req, courses):
     return num_courses
 
 def _course_match(course_name, pattern):
-    pattern = pattern.split(':')[0] # remove course title
-    pattern = ["".join(p.split()).upper() for p in pattern.split('/')] # split by '/' and
-    course = ["".join(c.split()).upper() for c in course_name.split('/')] # remove spaces
+    # remove course title
+    pattern = pattern.split(':')[0]
+    # equate SPI and WWS courses
+    course_name = course_name.replace("WWS", "SPI")
+    pattern = pattern.replace("WWS", "SPI")
+    # split by '/' and remove spaces
+    pattern = ["".join(p.split()).upper() for p in pattern.split('/')]
+    course = ["".join(c.split()).upper() for c in course_name.split('/')]
     for c in course:
         for p in pattern:
             if c == p: # exact name matched
@@ -668,6 +673,11 @@ def _get_collapsed_course_and_dist_req_sets(req):
             for course in req["course_list"]:
                 course = course.split(':')[0] # strip course name
                 course_set.add(course)
+                # if it's a SPI/WWS course, include both variations
+                if "WWS" in course:
+                    course_set.add(course.replace("WWS", "SPI"))
+                if "SPI" in course:
+                    course_set.add(course.replace("SPI", "WWS"))
         if "dist_req" in req:
             dist = req["dist_req"]
             if isinstance(dist, str):  # backwards compatibility with non-list dist_req


### PR DESCRIPTION
The department was renamed, but only courses from Fall 2020 and later have the new `SPI` code, so we still need to support both `SPI` and `WWS` courses.
This pull request makes them behave functionally the same.

It's a bit hacky of course, but it's the simplest way to implement this transition while maintaining backwards compatibility.

Since there are currently no `SPI` courses in the database, it won't have any meaningful effect until the Fall 2020 courses are rescraped.