### PR TITLE
Allow ISC 231-234 to satisfy COS 126 pre-req for COS AB and BSE majors

### DIFF
--- a/tigerpath/majors_and_certificates/majors/COS-AB.json
+++ b/tigerpath/majors_and_certificates/majors/COS-AB.json
@@ -65,10 +65,54 @@
           "max_counted": 1,
           "min_needed": "ALL",
           "explanation": "The three prerequisite computer science courses introduce the core concepts and techniques of the field.",
-          "course_list": [
-            "COS 126",
-            "COS 217",
-            "COS 226"
+          "req_list": [
+            {
+              "name": null,
+              "max_counted": 1,
+              "min_needed": 1,
+              "explanation": null,
+              "req_list": [
+                {
+                  "name": null,
+                  "max_counted": 1,
+                  "min_needed": 1,
+                  "explanation": null,
+                  "course_list": [
+                    "COS 126"
+                  ]
+                },
+                {
+                  "name": null,
+                  "max_counted": 1,
+                  "min_needed": "ALL",
+                  "explanation": null,
+                  "course_list": [
+                    "ISC 231",
+                    "ISC 232",
+                    "ISC 233",
+                    "ISC 234"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": null,
+              "max_counted": 1,
+              "min_needed": 1,
+              "explanation": null,
+              "course_list": [
+                "COS 217"
+              ]
+            },
+            {
+              "name": null,
+              "max_counted": 1,
+              "min_needed": 1,
+              "explanation": null,
+              "course_list": [
+                "COS 226"
+              ]
+            }
           ]
         }
       ]

--- a/tigerpath/majors_and_certificates/majors/COS-BSE.json
+++ b/tigerpath/majors_and_certificates/majors/COS-BSE.json
@@ -35,13 +35,57 @@
       "name": "Prerequisites",
       "max_counted": 1,
       "min_needed": "ALL",
-      "explanation": "All BSE students must meet the School of Engineering and Applied Science general requirements. Students must complete 126, 217, and 226. Students should plan to take both 217 and 226 before the junior year. One or both of these are required prerequisites for all later computer science courses.",
+      "explanation": "All BSE students must meet the School of Engineering and Applied Science general requirements. Students must complete 126 (or take all of ISC 231-234), 217, and 226. Students should plan to take both 217 and 226 before the junior year. One or both of these are required prerequisites for all later computer science courses.",
       "pdfs_allowed": false,
       "completed_by_semester": 4,
-      "course_list": [
-        "COS 126",
-        "COS 217",
-        "COS 226"
+      "req_list": [
+        {
+          "name": null,
+          "max_counted": 1,
+          "min_needed": 1,
+          "explanation": null,
+          "req_list": [
+            {
+              "name": null,
+              "max_counted": 1,
+              "min_needed": 1,
+              "explanation": null,
+              "course_list": [
+                "COS 126"
+              ]
+            },
+            {
+              "name": null,
+              "max_counted": 1,
+              "min_needed": "ALL",
+              "explanation": null,
+              "course_list": [
+                "ISC 231",
+                "ISC 232",
+                "ISC 233",
+                "ISC 234"
+              ]
+            }
+          ]
+        },
+        {
+          "name": null,
+          "max_counted": 1,
+          "min_needed": 1,
+          "explanation": null,
+          "course_list": [
+            "COS 217"
+          ]
+        },
+        {
+          "name": null,
+          "max_counted": 1,
+          "min_needed": 1,
+          "explanation": null,
+          "course_list": [
+            "COS 226"
+          ]
+        }
       ]
     },
     {


### PR DESCRIPTION
Fixes #382 by creating a hidden sub-requirement for COS 126 within COS-BSE.json and COS-AB.json. This hidden sub-req allows both COS 126 and all of ISC 231-234 to satisfy the COS 126 pre-req for these majors.