### PR TITLE
Add .idea/ to .gitignore to ignore folder generated by pycharm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,7 @@ venv.bak/
 
 # vscode
 .vscode
+
+# Jetbrains
+
+.idea/


### PR DESCRIPTION
I'm using PyCharm and it automatically generates a .idea/ folder for my workspace settings. These are user-specific and should not be committed to VCS.