### PR TITLE
Make scraper more robust

### DIFF
--- a/tigerpath/scraper/scrape_import.py
+++ b/tigerpath/scraper/scrape_import.py
@@ -37,9 +37,8 @@ def _create_course_listing(listing, course_object, counter):
 
 def _create_semester(semester):
     semester_object, _ = Semester.objects.get_or_create(
-        start_date=semester['start_date'],
-        end_date=semester['end_date'],
-        term_code=semester['term_code']
+        term_code=semester['term_code'],
+        defaults={'start_date': semester['start_date'], 'end_date': semester['end_date']}
     )
     return semester_object
 

--- a/tigerpath/scraper/scrape_parse.py
+++ b/tigerpath/scraper/scrape_parse.py
@@ -160,6 +160,7 @@ def scrape_parse_semester(term_code):
             return found
         elif (found is None or found.text is None):
             ParseError("key " + key + " does not exist")
+            return ''
         else:
             return h.unescape(found.text)
 
@@ -242,7 +243,7 @@ def scrape_parse_semester(term_code):
             return {
                 "title": get_text('title', course),
                 "guid": get_text('guid', course),
-                "distribution_area": get_text('distribution_area', course, fail_ok=True),
+                "distribution_area": get_text('distribution_area', course),
                 "description": none_to_empty(course.find('detail').find('description').text),
                 "semester": get_current_semester(),
                 "professors": [parse_prof(x) for x in course.find('instructors')],

--- a/tigerpath/scraper/scrape_validate.py
+++ b/tigerpath/scraper/scrape_validate.py
@@ -79,6 +79,7 @@ def validate_course(course):
         'title': validate_string_not_empty,
         'guid': validate_string_not_empty,
         'description': validate_string,
+        'distribution_area': validate_string,
         'semester': lambda x: validate_dict(x, semester_validator),
         'professors': lambda array: validate_array(array, lambda prof: validate_dict(prof, professor_validator)),
         'course_listings': lambda array: validate_array(array, lambda listing: validate_dict(listing, listing_validator)),


### PR DESCRIPTION
This PR makes the scraper more robust by fixing several issues that I ran into while running it.

Specifically:
- It fixes an error which can occur if a `term_code` already exists in the database and the `start_date` or `end_date` are different
- Ensures that `distribution_area` is always a string (before, it could sometimes be a object)