### PR TITLE
Fix requirements pane issue

### DIFF
--- a/tigerpath/majors_and_certificates/scripts/verifier.py
+++ b/tigerpath/majors_and_certificates/scripts/verifier.py
@@ -541,9 +541,15 @@ def _mark_dist(req, courses):
         for c in sem:
             if req["path_to"] in c["possible_reqs"]: # already used
                 continue
-            if dist_areas is None:
+            print("in _mark_dist")
+            print("c['dist_area']")
+            print(c["dist_area"])
+            print(type(c["dist_area"]))
+            if c["dist_area"] is None:
                 continue
             dist_areas = c["dist_area"].split(',')
+            print("after split")
+            print(dist_areas)
             if bool(set(dist_areas) & set(req["dist_req"])):
                 num_marked += 1
                 c["possible_reqs"].append(req["path_to"])

--- a/tigerpath/majors_and_certificates/scripts/verifier.py
+++ b/tigerpath/majors_and_certificates/scripts/verifier.py
@@ -541,6 +541,8 @@ def _mark_dist(req, courses):
         for c in sem:
             if req["path_to"] in c["possible_reqs"]: # already used
                 continue
+            if dist_areas is None:
+                continue
             dist_areas = c["dist_area"].split(',')
             if bool(set(dist_areas) & set(req["dist_req"])):
                 num_marked += 1

--- a/tigerpath/majors_and_certificates/scripts/verifier.py
+++ b/tigerpath/majors_and_certificates/scripts/verifier.py
@@ -541,15 +541,9 @@ def _mark_dist(req, courses):
         for c in sem:
             if req["path_to"] in c["possible_reqs"]: # already used
                 continue
-            print("in _mark_dist")
-            print("c['dist_area']")
-            print(c["dist_area"])
-            print(type(c["dist_area"]))
             if c["dist_area"] is None:
                 continue
             dist_areas = c["dist_area"].split(',')
-            print("after split")
-            print(dist_areas)
             if bool(set(dist_areas) & set(req["dist_req"])):
                 num_marked += 1
                 c["possible_reqs"].append(req["path_to"])


### PR DESCRIPTION
## Summary

#461 changed how distribution areas are stored and interpreted, but it assumed that `dist_area` was always of type string. When adding external credits in the frontend, `dist_area` is set to `None`, causing the function `_mark_dist` in `tigerpath/tigerpath/majors_and_certificates/scripts/verifier.py` to throw. This PR fixes that issue by first checking if `dist_area` is `None`.

## Fixed behavior


https://user-images.githubusercontent.com/13815069/194714523-de8153aa-f577-44b4-9d65-cbead32d3f68.mp4


## Broken behavior


https://user-images.githubusercontent.com/13815069/194714547-00dfb5e9-921f-406c-9a66-805774722372.mov
