### PR TITLE
Rename WWS to SPI

### DIFF
--- a/tigerpath/fixtures/major_mappings.json
+++ b/tigerpath/fixtures/major_mappings.json
@@ -304,7 +304,7 @@
     "pk": 31,
     "fields": {
       "name": "Public and International Affairs",
-      "code": "WWS",
+      "code": "SPI",
       "degree": "AB",
       "supported": true
     }

--- a/tigerpath/majors_and_certificates/scripts/university_info.py
+++ b/tigerpath/majors_and_certificates/scripts/university_info.py
@@ -142,8 +142,8 @@ AB_DEPTS = {
     "REL": "Religion",
     "SLA": "Slavic Languages and Lit",
     "SOC": "Sociology",
+    "SPI": "Public and International Affairs",
     "SPO": "Spanish and Portuguese",
-    "WWS": "Public and International Affairs",
 }
 
 AB_CONCENTRATIONS = {
@@ -176,8 +176,8 @@ AB_CONCENTRATIONS = {
     "REL": "Religion",
     "SLA": "Slavic Languages and Literatures",
     "SOC": "Sociology",
+    "SPI": "Public and International Affairs",
     "SPO": "Spanish and Portuguese",
-    "WWS": "Public and International Affairs",
 }
 
 BSE_CONCENTRATIONS = {


### PR DESCRIPTION
## Summary

TigerPath recently switched to using the [shared course data repo](https://github.com/PrincetonUSG/Princeton-Departmental-Data). In this repo, WWS is renamed to SPI and this resulted in a frontend bug. This PR resolves that bug by renaming WWS to SPI.