### PR TITLE
Fix onboarding issue for first-time users

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -2,7 +2,7 @@ from .base import *
 import os
 
 
-DEBUG = True
+DEBUG = False
 ADMIN_ENABLED = True
 
 WEBPACK_LOADER = {

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -2,7 +2,7 @@ from .base import *
 import os
 
 
-DEBUG = False
+DEBUG = True
 ADMIN_ENABLED = True
 
 WEBPACK_LOADER = {

--- a/tigerpath/utils.py
+++ b/tigerpath/utils.py
@@ -6,6 +6,7 @@ import requests
 
 TIGERBOOK_BASE_URL = "https://tigerbook.herokuapp.com/api/v1/undergraduates/"
 
+# DO NOT CALL THIS METHOD WHILE TIGERBOOK API IS DOWN.
 # Get information about the student with the specified netid from Tigerbook
 def get_student_info(netid):
     url = TIGERBOOK_BASE_URL + netid

--- a/tigerpath/views.py
+++ b/tigerpath/views.py
@@ -51,8 +51,8 @@ def index(request):
             # the user has completed the onboarding form but not the tutorial
             if not request.user.profile.major:
                 # add onboarding form
-                initial_values = get_onboarding_initial_values(request.user.username)
-                onboarding_form = forms.OnboardingForm(initial=initial_values)
+                # initial_values = get_onboarding_initial_values(request.user.username)
+                onboarding_form = forms.OnboardingForm()
                 context["onboarding_form"] = onboarding_form
             else:
                 # show tutorial

--- a/tigerpath/views.py
+++ b/tigerpath/views.py
@@ -51,7 +51,6 @@ def index(request):
             # the user has completed the onboarding form but not the tutorial
             if not request.user.profile.major:
                 # add onboarding form
-                # initial_values = get_onboarding_initial_values(request.user.username)
                 onboarding_form = forms.OnboardingForm()
                 context["onboarding_form"] = onboarding_form
             else:


### PR DESCRIPTION
## Summary

First-time users (as of around 2/6/2023) received 500 Error when trying to login for the first time. Tigerpath queries the TigerBook API for first-time users in an attempt to pre-populate their major and year, but since TigerBook API is down, the query was throwing an error.

We've removed the functionality to pre-populate major/year. New users will now have to select their major/year from dropdowns.

Collaborator: @nicholaspad 