### PR TITLE
Fix remote data url

### DIFF
--- a/tigerpath/majors_and_certificates/scripts/verifier.py
+++ b/tigerpath/majors_and_certificates/scripts/verifier.py
@@ -11,7 +11,7 @@ import requests
 from . import university_info
 
 REMOTE_DATA_REPO_URL = (
-    "https://raw.githubusercontent.com/PrincetonUSG/Princeton-Departmental-Data/main/"
+    "https://raw.githubusercontent.com/TigerAppsOrg/Princeton-Departmental-Data/old"
 )
 
 MAJORS_LOCATION = (


### PR DESCRIPTION
Temporarily changed the departmental data url to a branch that contains the old data. The new data seems to cause some internal issues, so I'm having TigerPath use the old data until that issue is resolved so the app is functional for the time being.