### PR TITLE
Feature: Add Security-Gated Admin Dashboard & Admin Management

### DIFF
--- a/tigerpath/templates/tigerpath/admin/admin_dashboard.html
+++ b/tigerpath/templates/tigerpath/admin/admin_dashboard.html
@@ -1,0 +1,41 @@
+<h1>TigerPath Admin Dashboard</h1>
+
+{% if messages %}
+  <ul style="color: red; font-weight: bold;">
+    {% for message in messages %}
+      <li>{{ message }}</li>
+    {% endfor %}
+  </ul>
+{% endif %}
+
+<hr>
+
+<h3>Add New Admin</h3>
+<form method="POST">
+    {% csrf_token %}
+    <input type="hidden" name="action" value="add">
+    <label for="add_netid">Student NetID:</label>
+    <input type="text" id="add_netid" name="netid" required>
+    <button type="submit">Make Admin</button>
+</form>
+
+{% if request.user.is_superuser %}
+<hr>
+<h3>Remove Admin (Owner Only)</h3>
+<form method="POST">
+    {% csrf_token %}
+    <input type="hidden" name="action" value="remove">
+    <label for="remove_netid">Student NetID:</label>
+    <input type="text" id="remove_netid" name="netid" required>
+    <button type="submit" style="color: red;">Remove Admin</button>
+</form>
+<hr>
+<h3>Add Owner (Owner Only)</h3>
+<form method="POST">
+    {% csrf_token %}
+    <input type="hidden" name="action" value="add_owner">
+    <label for="add_netid_superuser">Student NetID:</label>
+    <input type="text" id="add_netid_superuser" name="netid" required>
+    <button type="submit" style="color: black;">Add Owner</button>
+</form>
+{% endif %}

--- a/tigerpath/urls.py
+++ b/tigerpath/urls.py
@@ -30,4 +30,5 @@ urlpatterns = [
         views.update_schedule_and_get_requirements,
         name="update_schedule_and_get_requirements",
     ),
+    path('admin/admin-dashboard/', views.admin_dashboard, name='admin_dashboard'),
 ]

--- a/tigerpath/views.py
+++ b/tigerpath/views.py
@@ -460,9 +460,12 @@ def admin_dashboard(request):
             target_user = User.objects.get(username=netid)
 
             if action == 'add':
-                target_user.is_staff = True
-                target_user.save()
-                messages.success(request, f"Successfully made {netid} an admin.")
+                if target_user.is_staff:
+                    messages.error(request, f"{netid} is already an admin.")
+                else:
+                    target_user.is_staff = True
+                    target_user.save()
+                    messages.success(request, f"Successfully made {netid} an admin.")
 
             elif action == 'remove':
                 # Only superusers (Owners) can remove admins
@@ -476,10 +479,15 @@ def admin_dashboard(request):
                     messages.success(request, f"Successfully removed admin rights from {netid}.")
             
             elif action == 'add_owner':
-                target_user.is_staff = True
-                target_user.is_superuser = True
-                target_user.save()
-                messages.success(request, f"Successfully made {netid} an owner.")
+                if not request.user.is_superuser:
+                    messages.error(request, "Action Denied: You must be an Owner to add owners.")
+                elif target_user.is_superuser:
+                   messages.error(request, f"{netid} is already an owner.")
+                else: 
+                    target_user.is_staff = True
+                    target_user.is_superuser = True
+                    target_user.save()
+                    messages.success(request, f"Successfully made {netid} an owner.")
 
         except User.DoesNotExist:
             messages.error(request, f"User with NetID {netid} not found.")


### PR DESCRIPTION
Security gated admin page that requires users to be Django staff (or superuser) to access. Users without access get redirected to the login page if not signed in and to the course planner/home page if logged in. Staff are able to 


Currently, this dashboard allows existing admins to:
- Promote other users to Admin status (via NetID).
- [Owner Only] Revoke Admin status from users.
- [Owner Only] Grant Owner status to other users.

Key Changes:

- New View (admin_dashboard): Created a new view protected by a custom @admin_required decorator.
- Custom Decorator: Implemented a security check that redirects unauthorized users (non-admins) to the home page with a flash error message.
- Admin Management: Added a form to the dashboard to promote users to is_staff.
- Owner Privileges: Added a "Remove Admin" and "Add Owner" form that is only visible and accessible to Superusers (Owners).
- Templates: Added admin_dashboard.html

How to Test
1. Create the First Admin (Manual DB Override)
Since the dashboard is gated, you must manually promote yourself to access it for the first time.
cd to directory containing manage.py, then run:

```
python manage.py shell
```

Then, run the following commands:

```
from django.contrib.auth.models import User
me = User.objects.get(username='YOUR_NETID')
me.is_staff = True
me.is_superuser = True  # Required to test "Remove Admin" feature
me.save()
exit()
```

2. Access the Dashboard

- Navigate to: http://localhost:8000/admin-dashboard/
- Verify you can see the "Add Admin" and "Remove Admin" forms.

3. Test Functionality
- Add Admin: Enter another valid NetID (e.g., a test user) and click "Make Admin." Verify in the Django admin panel or shell that their is_staff status is now True.
- Remove Admin: Enter that same NetID and click "Remove Admin." Verify their status is now False.
- Permissions:
- In the shell, set `me.is_superuser = False` and refresh the page. The "Remove Admin" form and "Add Owner" form should disappear.
- In the shell, set `me.is_staff = False` and refresh. You should be redirected to the home page with an "Access Denied" error message.

https://github.com/user-attachments/assets/84abe509-e9d2-4038-bc10-ab516187ecbd
