### PR TITLE
(bug) fix local Vite asset prefix

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -164,6 +164,7 @@ DJANGO_VITE = {
         "dev_mode": os.getenv("DJANGO_VITE_DEV_MODE", "False").lower() in ("true", "1"),
         "dev_server_host": "localhost",
         "dev_server_port": 3000,
+        "static_url_prefix": "dist",
         "manifest_path": os.path.join(REACT_BASE_DIR, "assets", "dist", "manifest.json"),
     }
 }


### PR DESCRIPTION
## What does this PR do?

- Aligns Django Vite dev URLs with the configured Vite `base`.
- Fixes the local blank or unstyled preview caused by the missing `dist` static URL prefix.
- Keeps the change scoped to local dev asset serving.

## Why?

The local preview could render blank because Django generated dev-server asset URLs that did not match Vite's configured path prefix.

## How to test

- Start the Django server with `DJANGO_VITE_DEV_MODE=True`.
- Start Vite locally.
- Verify the app loads frontend assets from `/static/dist/...`.

## Screenshots

### Dashboard Before

![Dashboard before](https://raw.githubusercontent.com/TigerAppsOrg/TigerPath/tigerpath-pr-screenshots-2026-05-01/pr-media/before-dashboard.png)

### Dashboard After

![Dashboard after](https://raw.githubusercontent.com/TigerAppsOrg/TigerPath/tigerpath-pr-screenshots-2026-05-01/pr-media/after-dashboard.png)

## Verification

- Verified Vite serves `http://localhost:3000/static/dist/src/landing.jsx`.
- Screenshot verification used localhost with `DATABASE_URL=postgres:///tigerpath`.

## Note

This entire PR was automatically implemented, tested, and written by Codex.
