### PR TITLE
(bug) fix registrar seed TLS verification

### DIFF
--- a/tigerpath/scraper/scrape_registrar.py
+++ b/tigerpath/scraper/scrape_registrar.py
@@ -11,6 +11,7 @@ import re
 from concurrent.futures import ThreadPoolExecutor
 
 import cloudscraper
+import certifi
 import requests
 
 _REGISTRAR_PAGE_URL = "https://registrar.princeton.edu/course-offerings"
@@ -32,6 +33,7 @@ def _fetch_registrar_page():
         _REGISTRAR_PAGE_URL,
         headers={"User-Agent": _USER_AGENT},
         timeout=30,
+        verify=certifi.where(),
     )
     resp.raise_for_status()
     html = resp.text


### PR DESCRIPTION
## What does this PR do?

- Uses Certifi's CA bundle for registrar seeding requests.
- Fixes local course seed/import TLS failures without changing production data.
- Keeps the scraper change isolated to request verification setup.

## Why?

Local course seeding can fail when the Python/OpenSSL trust store cannot validate the registrar endpoint. Using Certifi gives the scraper a stable CA bundle without weakening TLS verification.

## How to test

- Run the registrar course seed/import path locally.
- Confirm requests verify successfully without disabling TLS verification.

## Screenshots

No UI surface changes in this PR.

## Verification

- Django tests passed locally as part of dashboard branch verification: `19 passed`.
- Local database only: `DATABASE_URL=postgres:///tigerpath`.

## Note

This entire PR was automatically implemented, tested, and written by Codex.
